### PR TITLE
fix(setup): read README.md as UTF-8 for Windows compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import find_packages, setup
 
-with open("README.md") as readme_file:
+with open("README.md", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 requirements = [


### PR DESCRIPTION
Problème

pip install -e . échoue sous Windows avec l'erreur suivante :

UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1022:
character maps to <undefined>

setup.py ligne 5 ouvre README.md sans préciser d'encodage. Python utilise alors l'encodage par défaut du système, soit UTF-8 sous Linux et macOS, mais cp1252 sous Windows. Le README contenant des emoji, le décodage échoue et l'installation en mode éditable est impossible.

Correctif

Ajout de encoding="utf-8" à l'ouverture du fichier. Comportement inchangé sur les autres plateformes.

Vérification

Testé sous Windows 11, Python 3.12 : pip install -e . échoue avant le correctif, aboutit après.